### PR TITLE
#426: mapping of file name extension to nuke extension in choices.

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -90,8 +90,9 @@ keys:
     img_extension:
         type: str
         choices:
-            exr: EXR
-            jpg: JPEG
+            exr: exr
+            jpg: jpeg
+            tiff: tiff
         default: exr
         alias: extension
     geo_extension:


### PR DESCRIPTION
extensions choices now contains a map of extension in file name to extension expected by Nuke (e.g. jpg: jpeg)