### PR TITLE
#442 and #377: tk-multi-reviewsubmission settings

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -238,6 +238,10 @@ paths:
     sequence_asset_publish_cache:           '@sequence_asset_publish_area_anim/@sequence_asset_version_name.{geo_extension}'
     shot_asset_publish_cache:               '@shot_asset_publish_area_anim/@shot_asset_version_name.{geo_extension}'
 
+    # REVIEW SUBMISSION
+    reviewsubmission_burnin_nuke_file:      '@project_publish_area/SCRIPT/slate/burnin.nk'
+    reviewsubmission_slate_logo_file:       '@project_publish_area/SCRIPT/slate/logo.png'
+
 #
 # The aliases section allows you to map one template to another without worrying
 # about Toolkit complaining about collisions. When an alias is requested, Toolkit

--- a/env/includes/settings/apps/tk-multi-reviewsubmission.yml
+++ b/env/includes/settings/apps/tk-multi-reviewsubmission.yml
@@ -23,9 +23,8 @@ settings.tk-multi-reviewsubmission:
   movie_height: '@settings.tk-multi-reviewsubmission.height'
   movie_path_template: '{env_name}_publish_movie'
   sg_version_name_template: '{env_name}_version_name'
-  slate_logo: 'icons/review_submit_logo.png'
+  slate_logo: 'reviewsubmission_slate_logo_file'
   codec_settings_hook: '{config}/codec_settings.py'
   location: "@apps.tk-multi-reviewsubmission.location"
   nuke_linux_path: "@path.linux.nuke"
-  burnin_path_template: 'reviewsubmission_burnin_nuke_file'
-  slate_logo_template: 'reviewsubmission_slate_logo_file'
+  burnin_path: 'reviewsubmission_burnin_nuke_file'

--- a/env/includes/settings/apps/tk-multi-reviewsubmission.yml
+++ b/env/includes/settings/apps/tk-multi-reviewsubmission.yml
@@ -27,3 +27,5 @@ settings.tk-multi-reviewsubmission:
   codec_settings_hook: '{config}/codec_settings.py'
   location: "@apps.tk-multi-reviewsubmission.location"
   nuke_linux_path: "@path.linux.nuke"
+  burnin_path_template: 'reviewsubmission_burnin_nuke_file'
+  slate_logo_template: 'reviewsubmission_slate_logo_file'

--- a/env/includes/settings/apps/tk-multi-reviewsubmission.yml
+++ b/env/includes/settings/apps/tk-multi-reviewsubmission.yml
@@ -12,6 +12,7 @@
 
 includes:
 - ../../app_locations.yml
+- ../../software_paths.yml
 
 ################################################################################
 # NOTE: Reviewsubmission settings have been moved to {preferences}/sgtk_config_environments.yaml
@@ -25,3 +26,4 @@ settings.tk-multi-reviewsubmission:
   slate_logo: 'icons/review_submit_logo.png'
   codec_settings_hook: '{config}/codec_settings.py'
   location: "@apps.tk-multi-reviewsubmission.location"
+  nuke_linux_path: "@path.linux.nuke"

--- a/env/includes/settings/tk-maya.yml
+++ b/env/includes/settings/tk-maya.yml
@@ -16,6 +16,7 @@ includes:
 - ../engine_locations.yml
 - ./apps/tk-multi-loader2.yml
 - ./apps/tk-multi-publish2.yml
+- ./apps/tk-multi-reviewsubmission.yml
 - ./apps/tk-multi-screeningroom.yml
 - ./apps/tk-multi-shotgunpanel.yml
 - ./apps/tk-multi-snapshot.yml
@@ -30,6 +31,7 @@ settings.tk-maya:
       location: "@apps.tk-multi-about.location"
     tk-multi-loader2: '@settings.tk-multi-loader2.maya'
     tk-multi-publish2: '@settings.tk-multi-publish2.maya'
+    tk-multi-reviewsubmission: "@settings.tk-multi-reviewsubmission"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.maya"
@@ -48,6 +50,7 @@ settings.tk-maya.asset:
       location: "@apps.tk-multi-breakdown.location"
     tk-multi-loader2: "@settings.tk-multi-loader2.maya"
     tk-multi-publish2: "@settings.tk-multi-publish2.maya"
+    tk-multi-reviewsubmission: "@settings.tk-multi-reviewsubmission"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.maya"
     tk-multi-snapshot: "@settings.tk-multi-snapshot"
@@ -73,6 +76,7 @@ settings.tk-maya.shot:
       location: "@apps.tk-multi-setframerange.location"
     tk-multi-loader2: "@settings.tk-multi-loader2.maya"
     tk-multi-publish2: "@settings.tk-multi-publish2.maya"
+    tk-multi-reviewsubmission: "@settings.tk-multi-reviewsubmission"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.maya"
     tk-multi-snapshot: "@settings.tk-multi-snapshot"


### PR DESCRIPTION
Added settings to make burnin.nk and logo file configurable (the template paths can be overridden using our preferences system per seq/shot/role as necessary). 
Added settings to support nuke subprocess.