### PR TITLE
Fixed project root path appearing twice

### DIFF
--- a/hooks/tk-hiero-export/hiero_get_quicktime_settings.py
+++ b/hooks/tk-hiero-export/hiero_get_quicktime_settings.py
@@ -33,7 +33,7 @@ class HieroGetQuicktimeSettings(HookBaseClass):
         """
         import nuke
 
-        if sys.platform.startswith("linux") and nuke.NUKE_VERSION_MAJOR < 11:
+        if sys.platform.startswith("linux") and nuke.NUKE_VERSION_MAJOR < 12:
 
             file_type = "mov"
             properties = {

--- a/hooks/tk-hiero-export/hiero_translate_template.py
+++ b/hooks/tk-hiero-export/hiero_translate_template.py
@@ -99,6 +99,6 @@ class HieroTranslateTemplate(HookBaseClass):
             fields["name"] = "plate"
             del fields['output']
 
-        template_str = template.apply_fields(fields, ignore_types=hiero_fields.keys())
+        template_str = template.apply_fields(fields, ignore_types=hiero_fields.keys()).replace(template.root_path, "")
 
         return template_str


### PR DESCRIPTION
Nuke Studio - fixed project path appearing twice in the shotgun hiero export UI