### PR TITLE
#1296: fix Alembic Cache typo

### DIFF
--- a/env/includes/settings/apps/tk-multi-loader2.yml
+++ b/env/includes/settings/apps/tk-multi-loader2.yml
@@ -63,7 +63,7 @@ settings.tk-multi-loader2.mari:
 # maya
 settings.tk-multi-loader2.maya:
   action_mappings:
-    ALembic Cache: [reference, import]
+    Alembic Cache: [reference, import]
     Image: [image_plane, texture_node_with_frames]
     Maya Scene: [reference, import]
     Model File: [reference, import]


### PR DESCRIPTION
Fix typo to show `Alembic Cache` published files in maya loader.