### PR TITLE
#1786: nuke validation comp - use fields['output'] instead of knob 

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -121,6 +121,13 @@ keys:
             dpx: dpx
         default: exr
         alias: extension
+    deep.ext:
+        type: str
+        choices:
+            exr: exr
+            dtex: dtex
+        default: exr
+        alias: extension
     geo.ext:
         type: str
         choices:
@@ -345,6 +352,15 @@ paths:
     sequence_asset_publish_render:          '@sequence_asset_publish_area_image/@image_subdirs/@sequence_asset_version_name.{SEQ}.{img.ext}'
     shot_asset_publish_render:              '@shot_asset_publish_area_image/@image_subdirs/@shot_asset_version_name.{SEQ}.{img.ext}'
 
+    # DEEP RENDERS
+    project_publish_deep_render:            '@project_publish_area_image/@deep_subdirs/@project_version_name.{SEQ}.{deep.ext}'
+    sequence_publish_deep_render:           '@sequence_publish_area_image/@deep_subdirs/@sequence_version_name.{SEQ}.{deep.ext}'
+    shot_publish_deep_render:               '@shot_publish_area_image/@deep_subdirs/@shot_version_name.{SEQ}.{deep.ext}'
+
+    project_asset_publish_deep_render:      '@project_asset_publish_area_image/@deep_subdirs/@project_asset_version_name.{SEQ}.{deep.ext}'
+    sequence_asset_publish_deep_render:     '@sequence_asset_publish_area_image/@deep_subdirs/@sequence_asset_version_name.{SEQ}.{deep.ext}'
+    shot_asset_publish_deep_render:         '@shot_asset_publish_area_image/@deep_subdirs/@shot_asset_version_name.{SEQ}.{deep.ext}'
+
     # MOVIES
     project_publish_movie:                  '@project_publish_area_movie/@project_version_name.mov'
     sequence_publish_movie:                 '@sequence_publish_area_movie/@sequence_version_name.mov'
@@ -474,6 +490,7 @@ strings:
     # COMMON
     user_work:                              'work.{User}'
     image_subdirs:                          '{name}/v{version}/{width}x{height}'
+    deep_subdirs:                           '{name}/v{version}/deep/{width}x{height}'
     playblast_subdirs:                      'playblasts/{name}/v{version}'
     proxy_subdirs:                          '{name}/v{version}/PROXY'
     2k_subdirs:                             '{name}/v{version}/2K'

--- a/core/templates/nuke.yml
+++ b/core/templates/nuke.yml
@@ -51,6 +51,15 @@ paths:
     tk-nuke_sequence_asset_work_render:         '@tk-nuke_sequence_asset_work_area/images/{Step}/@image_subdirs/@sequence_asset_version_name.{SEQ}.{img.ext}'
     tk-nuke_shot_asset_work_render:             '@tk-nuke_shot_asset_work_area/images/{Step}/@image_subdirs/@shot_asset_version_name.{SEQ}.{img.ext}'
 
+    # DEEP RENDERS
+    tk-nuke_project_work_deep_render:           '@tk-nuke_project_work_area/images/{Step}/@deep_subdirs/@project_version_name.{SEQ}.{deep.ext}'
+    tk-nuke_sequence_work_deep_render:          '@tk-nuke_sequence_work_area/images/{Step}/@deep_subdirs/@sequence_version_name.{SEQ}.{deep.ext}'
+    tk-nuke_shot_work_deep_render:              '@tk-nuke_shot_work_area/images/{Step}/@deep_subdirs/@shot_version_name.{SEQ}.{deep.ext}'
+
+    tk-nuke_project_asset_work_deep_render:     '@tk-nuke_project_asset_work_area/images/{Step}/@deep_subdirs/@project_asset_version_name.{SEQ}.{deep.ext}'
+    tk-nuke_sequence_asset_work_deep_render:    '@tk-nuke_sequence_asset_work_area/images/{Step}/@deep_subdirs/@sequence_asset_version_name.{SEQ}.{deep.ext}'
+    tk-nuke_shot_asset_work_deep_render:        '@tk-nuke_shot_asset_work_area/images/{Step}/@deep_subdirs/@shot_asset_version_name.{SEQ}.{deep.ext}'
+
     # MOVIES
     tk-nuke_project_work_movie:                 '@tk-nuke_project_work_area/movies/@project_version_name.mov'
     tk-nuke_sequence_work_movie:                '@tk-nuke_sequence_work_area/movies/@sequence_version_name.mov'


### PR DESCRIPTION
Also, fix frame range check, add more logs.
This is needed if publishing normal nuke nodes (no tank knobs)