### PR TITLE
#1889: add loader tab to display shot and shot asset data

### DIFF
--- a/env/includes/settings/apps/tk-multi-loader2.yml
+++ b/env/includes/settings/apps/tk-multi-loader2.yml
@@ -33,6 +33,13 @@ settings.tk-multi-loader2.entities: &loader2_entities
     filters:
       - [project, is, '{context.project}']
     hierarchy: [sg_shot.Shot.sg_sequence, sg_shot, code]
+  - caption: Shot Data
+    type: Query
+    entity_type: Asset
+    filters:
+      - [project, is, '{context.project}']
+      - [sg_shot, is_not, null]
+    hierarchy: [sg_sequence, sg_shot, code]
 
 # houdini
 settings.tk-multi-loader2.houdini:


### PR DESCRIPTION
For current shows, where data is already linked to snapshot assets. This works because we have no actual shot assets, so all data within assets and directly linked to shot is just shot data.