### PR TITLE
#2212: configured nukestudio work_path and publish templates

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -235,6 +235,7 @@ paths:
     project_publish_area_movie:             '@project_publish_area/MOV/{Step}'
     project_publish_area_scene:             '@project_publish_area/SCENE/{Step}'
     project_publish_area_script:            '@project_publish_area/SCRIPT/{Step}'
+    project_publish_area_project:           '@project_publish_area/PROJECT/{Step}'
     project_publish_area_sfx:               '@project_publish_area/SILHOUETTE/{Step}'
     project_publish_area_texture:           '@project_publish_area/TEXTURE/{Step}'
 
@@ -246,6 +247,7 @@ paths:
     sequence_publish_area_movie:            '@sequence_publish_area/MOV/{Step}'
     sequence_publish_area_scene:            '@sequence_publish_area/SCENE/{Step}'
     sequence_publish_area_script:           '@sequence_publish_area/SCRIPT/{Step}'
+    sequence_publish_area_project:          '@sequence_publish_area/PROJECT/{Step}'
     sequence_publish_area_sfx:              '@sequence_publish_area/SILHOUETTE/{Step}'
     sequence_publish_area_texture:          '@sequence_publish_area/TEXTURE/{Step}'
 
@@ -257,6 +259,7 @@ paths:
     shot_publish_area_movie:                '@shot_publish_area/MOV/{Step}'
     shot_publish_area_scene:                '@shot_publish_area/SCENE/{Step}'
     shot_publish_area_script:               '@shot_publish_area/SCRIPT/{Step}'
+    shot_publish_area_project:              '@shot_publish_area/PROJECT/{Step}'
     shot_publish_area_sfx:                  '@shot_publish_area/SILHOUETTE/{Step}'
     shot_publish_area_texture:              '@shot_publish_area/TEXTURE/{Step}'
 
@@ -333,9 +336,9 @@ paths:
     shot_asset_publish_nuke_script:         '@shot_asset_publish_area_script/@shot_asset_version_name.nk'
 
     # NUKESTUDIO PROJECTS
-    project_publish_nukestudio_project:     '@project_publish_area_script/@project_version_name.hrox'
-    sequence_publish_nukestudio_project:    '@sequence_publish_area_script/@sequence_version_name.hrox'
-    shot_publish_nukestudio_project:        '@shot_publish_area_script/@shot_version_name.hrox'
+    project_publish_nukestudio_project:     '@project_publish_area_project/@project_version_name.hrox'
+    sequence_publish_nukestudio_project:    '@sequence_publish_area_project/@sequence_version_name.hrox'
+    shot_publish_nukestudio_project:        '@shot_publish_area_project/@shot_version_name.hrox'
 
     # RENDERS
     project_publish_render:                 '@project_publish_area_image/@image_subdirs/@project_version_name.{SEQ}.{img.ext}'

--- a/core/templates/nukestudio.yml
+++ b/core/templates/nukestudio.yml
@@ -22,9 +22,9 @@ keys:
 paths:
 
     # WORK AREAS
-    tk-nukestudio_project_work_area:            './{department}/user/@user_work'
-    tk-nukestudio_sequence_work_area:           './{department}/{Sequence}/user/@user_work'
-    tk-nukestudio_shot_work_area:               './{department}/{Sequence}/{Shot}/user/@user_work'
+    tk-nukestudio_project_work_area:            './user/@user_work/nukestudio'
+    tk-nukestudio_sequence_work_area:           './{Sequence}/user/@user_work/nukestudio'
+    tk-nukestudio_shot_work_area:               './{Sequence}/{Shot}/user/@user_work/nukestudio'
 
     # WORK FILES
     tk-nukestudio_project_work_file:            '@tk-nukestudio_project_work_area/projects/@project_version_name.hrox'
@@ -37,9 +37,9 @@ paths:
     tk-nukestudio_shot_work_snapshot:           '@tk-nukestudio_shot_work_area/projects/snapshots/@shot_version_name.{timestamp}.hrox'
 
     # EXPORT RENDERS
-    tk-nukestudio_project_work_render:          '@tk-nukestudio_project_work_area/renders/{Sequence}/{Shot}/v{version}/@shot_version_name.{SEQ}.{img.ext}'
-    tk-nukestudio_sequence_work_render:         '@tk-nukestudio_sequence_work_area/renders/{Sequence}/{Shot}/v{version}/@shot_version_name.{SEQ}.{img.ext}'
-    tk-nukestudio_shot_work_render:             '@tk-nukestudio_shot_work_area/renders/{Sequence}/{Shot}/v{version}/@shot_version_name.{SEQ}.{img.ext}'
+    tk-nukestudio_project_work_render:          '@tk-nukestudio_project_work_area/renders/v{version}/@project_version_name.{SEQ}.{img.ext}'
+    tk-nukestudio_sequence_work_render:         '@tk-nukestudio_sequence_work_area/renders/v{version}/@sequence_version_name.{SEQ}.{img.ext}'
+    tk-nukestudio_shot_work_render:             '@tk-nukestudio_shot_work_area/renders/v{version}/@shot_version_name.{SEQ}.{img.ext}'
 
     # EXPORT PLATES
     tk-nukestudio_project_work_movie:           '@tk-nukestudio_project_work_area/movies/@project_version_name.mov'


### PR DESCRIPTION
Changed nukestudio work_path templates as per shotgun structure.
Ex:
       old path:  /dd/shows/{SHOW}/EDITORIAL/user/work.{USER}/projects/
       new path: /dd/shows/{SHOW}/user/work.{USER}/nukestudio/projects/

Added "PROJECT" folder in "SHARED" location for nukestudio file.