### PR TITLE
#3942: switch sg-file_save context based on selected project in nukestudio

### DIFF
--- a/env/includes/settings/apps/tk-multi-workfiles2.yml
+++ b/env/includes/settings/apps/tk-multi-workfiles2.yml
@@ -146,12 +146,14 @@ settings.tk-multi-workfiles2.nukestudio.task:
   file_extensions: ['hrox']
   entities: '@settings.tk-multi-workfiles2.entities.nukestudio'
   my_tasks_extra_display_fields: []
+  hook_scene_operation: '{config}/tk-multi-workfiles2/task_operations_base.py:{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py'
 
 settings.tk-multi-workfiles2.nukestudio:
   <<: *default_workfiles2_settings
   file_extensions: ['hrox']
   entities: '@settings.tk-multi-workfiles2.entities.nukestudio'
   my_tasks_extra_display_fields: []
+  hook_scene_operation: '{config}/tk-multi-workfiles2/task_operations_base.py:{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py'
 
 # silhouette task
 settings.tk-multi-workfiles2.silhouette.task:

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -80,7 +80,6 @@ class SceneOperation(HookClass):
         # specific methods.
 
         engine = self.parent.engine
-        print "engine:", engine
         if hasattr(engine, "hiero_enabled") and (engine.hiero_enabled or engine.studio_enabled):
             return self._scene_operation_hiero_nukestudio(
                 operation,
@@ -333,8 +332,7 @@ class SceneOperation(HookClass):
         import hiero
 
         engine = sgtk.platform.current_engine()
-        engine_context = engine.context
-        context_str = engine_context.serialize(engine_context)
+        context_str = engine.context.serialize(engine.context)
 
         if operation == "current_path":
             # return the current script path
@@ -344,8 +342,8 @@ class SceneOperation(HookClass):
                 # switch file-save window context to selected project context
                 project = self._get_current_hiero_project()
                 tag_object = self.get_tag_object(project)
-                context_str = tag_object.note()
-                selected_project_context = engine_context.deserialize(context_str, engine.tank)
+                selected_context_str = tag_object.note()
+                selected_project_context = sgtk.context.deserialize(selected_context_str, engine.tank)
                 self.parent.change_context(selected_project_context)
             return curr_path
 
@@ -377,9 +375,7 @@ class SceneOperation(HookClass):
 
         elif operation == "save_as":
             project = self._get_current_hiero_project()
-            if 'Untitled' in project.name():
-                # add tag for untitled project only
-                self.add_context_to_project(project, context_str, file_path)
+            self.add_context_to_project(project, context_str, file_path)
             project.saveAs(file_path.replace(os.path.sep, "/"))
 
             # ensure the save menus are displayed correctly

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -332,7 +332,7 @@ class SceneOperation(HookClass):
         import hiero
 
         engine = sgtk.platform.current_engine()
-        context_str = context.serialize(context)
+        context_str = context.serialize()
 
         if operation == "current_path":
             # return the current script path
@@ -430,12 +430,9 @@ class SceneOperation(HookClass):
         :param file_path:
         :return:
         """
-        if file_path:
-            return
-        else:
-            for tag_item in project.tagsBin().items():
-                if tag_item.name() == self.get_tag_name(project, file_path):
-                    return tag_item
+        for tag_item in project.tagsBin().items():
+            if tag_item.name() == self.get_tag_name(project, file_path):
+                return tag_item
         return
 
 

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -345,7 +345,7 @@ class SceneOperation(HookClass):
                 project = self._get_current_hiero_project()
                 tag_object = self.get_tag_object(project)
                 context_str = tag_object.note()
-                selected_project_context = engine_context.deserialize(context_str)
+                selected_project_context = engine_context.deserialize(context_str, engine.tank)
                 self.parent.change_context(selected_project_context)
             return curr_path
 

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -332,7 +332,7 @@ class SceneOperation(HookClass):
         import hiero
 
         engine = sgtk.platform.current_engine()
-        context_str = engine.context.serialize(engine.context)
+        context_str = context.serialize(context)
 
         if operation == "current_path":
             # return the current script path
@@ -343,7 +343,7 @@ class SceneOperation(HookClass):
                 project = self._get_current_hiero_project()
                 tag_object = self.get_tag_object(project)
                 selected_context_str = tag_object.note()
-                selected_project_context = sgtk.context.deserialize(selected_context_str, engine.tank)
+                selected_project_context = context.deserialize(selected_context_str, engine.tank)
                 self.parent.change_context(selected_project_context)
             return curr_path
 

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -343,7 +343,7 @@ class SceneOperation(HookClass):
                 project = self._get_current_hiero_project()
                 tag_object = self.get_tag_object(project)
                 selected_context_str = tag_object.note()
-                selected_project_context = context.deserialize(selected_context_str, engine.tank)
+                selected_project_context = sgtk.context.deserialize(selected_context_str, engine.tank)
                 self.parent.change_context(selected_project_context)
             return curr_path
 


### PR DESCRIPTION
Used Tags to store project context.
On file open add tags to respective project with serialized context in note attribute.
On file save switch sg-file_save context.