### PR TITLE
LOD abc publish to rename top group

### DIFF
--- a/hooks/tk-multi-publish2/maya/publish_lod_geometry.py
+++ b/hooks/tk-multi-publish2/maya/publish_lod_geometry.py
@@ -131,9 +131,6 @@ class MayaPublishGeometryPlugin(HookBaseClass):
                     }
 
                 })
-
-            self.logger.info("Attempting to recover original alembic file.")
-            self.logger.info("Recover Succesful.")
         finally:
             abc_archive.close()
 

--- a/hooks/tk-multi-publish2/maya/publish_lod_geometry.py
+++ b/hooks/tk-multi-publish2/maya/publish_lod_geometry.py
@@ -119,7 +119,7 @@ class MayaPublishGeometryPlugin(HookBaseClass):
         try:
             abc_archive.top.children.values()[0].name = rename_to
             abc_archive.write_to_file(publish_path, asOgawa=True)
-        except Exception:
+        except Exception as err:
             import traceback
             self.logger.error(
                 "Unhandled exceptions encountered.",
@@ -129,8 +129,9 @@ class MayaPublishGeometryPlugin(HookBaseClass):
                         "tooltip": "Show complete traceback",
                         "text": traceback.format_exc()
                     }
-
                 })
+
+            raise err
         finally:
             abc_archive.close()
 


### PR DESCRIPTION
Added the functionality to rename exported LOD alembic's top group name to the asset name, during model publish.