### PR TITLE
#4591: provided intField inputs for in_handle and out_handle in exportUI to update head_in and tail_out fields in shotgun

### DIFF
--- a/hooks/tk-hiero-export/hiero_customize_export_ui.py
+++ b/hooks/tk-hiero-export/hiero_customize_export_ui.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
+from sgtk.platform.qt import QtGui
 
 import hiero.core
 import hiero.ui
@@ -104,8 +105,28 @@ class HieroCustomizeExportUI(HookBaseClass):
             ),
         ]
 
+    def create_shot_processor_widget(self, parent_widget):
+        widget = QtGui.QGroupBox("Custom Properties", parent_widget)
+        widget.setLayout(QtGui.QFormLayout())
+        return widget
 
+    def get_shot_processor_ui_properties(self):
+        return [
+            dict(
+                label="In Handle:",
+                name="In_Handle",
+                value=int(),
+                tooltip="Calculate and update head_in field in shotgun",
+            ),
+            dict(
+                label="Out Handle:",
+                name="Out_Handle",
+                value=int(),
+                tooltip="Calculate and update tail_out field in shotgun",
+            )
+        ]
 
-
-
-
+    def set_shot_processor_ui_properties(self, widget, properties):
+        layout = widget.layout()
+        for label, prop in properties.iteritems():
+            layout.addRow(label, prop)

--- a/hooks/tk-hiero-export/hiero_update_shot.py
+++ b/hooks/tk-hiero-export/hiero_update_shot.py
@@ -31,9 +31,11 @@ class HieroUpdateShot(HookBaseClass):
 
         # apparently shotgun utility 'sync frame range' within Maya uses 'sg_head_in' and 'sg_tail_out'
         start_frame = entity_data['sg_cut_in']
-
-        entity_data['sg_head_in'] = start_frame
-        entity_data['sg_tail_out'] = entity_data['sg_head_in'] + entity_data['sg_cut_duration']
+        # get in_handle and out_handle from exportUI to calculate 'sg_head_in' and 'sg_tail_out'
+        in_handle = preset_properties.get("In_Handle")
+        out_handle = preset_properties.get("Out_Handle")
+        entity_data['sg_head_in'] = start_frame - in_handle
+        entity_data['sg_tail_out'] = start_frame + entity_data['sg_cut_duration'] - 1 + out_handle
 
         self.parent.logger.debug(
             "Updating info for %s %s: %s" % (entity_type, entity_id, entity_data)


### PR DESCRIPTION
Nuke Studio:
The current tool setup updates the same value for (cut_in and head_in) and (cut_out and tail_out).
Updated code to update head_in and tail_out based on user input from exportUI.