### PR TITLE
#5272: Nukestudio-shotgun shot export will update smart fields in shotgun

### DIFF
--- a/hooks/tk-hiero-export/hiero_update_shot.py
+++ b/hooks/tk-hiero-export/hiero_update_shot.py
@@ -36,6 +36,12 @@ class HieroUpdateShot(HookBaseClass):
         out_handle = preset_properties.get("Out_Handle")
         entity_data['sg_head_in'] = start_frame - in_handle
         entity_data['sg_tail_out'] = start_frame + entity_data['sg_cut_duration'] - 1 + out_handle
+        entity_data['sg_working_duration'] = entity_data['sg_tail_out'] - entity_data['sg_head_in'] + 1
+        # update smart fields
+        entity_data['smart_head_in'] = entity_data['sg_head_in']
+        entity_data['smart_tail_out'] = entity_data['sg_tail_out']
+        entity_data['smart_cut_in'] = entity_data['sg_cut_in']
+        entity_data['smart_cut_out'] = entity_data['sg_cut_out']
 
         self.parent.logger.debug(
             "Updating info for %s %s: %s" % (entity_type, entity_id, entity_data)


### PR DESCRIPTION
As per editors request modified code to update smart fields smart_head_in, smart_tail_out, smart_cut_in and smart_cut_out.

Also updated code to update raw field sg_working_duration.