### PR TITLE
Bug-5145

### DIFF
--- a/env/includes/settings/apps/tk-multi-publish2.yml
+++ b/env/includes/settings/apps/tk-multi-publish2.yml
@@ -54,6 +54,7 @@ settings.tk-multi-publish2.nuke.publish_files:          '@settings.tk-multi-publ
 settings.tk-multi-publish2.nuke.publish_session:        '@settings.tk-multi-publish2.basic.publish_session:{self}/nuke/publish_session.py:{config}/tk-multi-publish2/nuke/publish.py'
 settings.tk-multi-publish2.nuke.create_version:         '@settings.tk-multi-publish2.basic.create_version:{self}/nuke/create_version.py'
 settings.tk-multi-publish2.nuke.upload_version:         '@settings.tk-multi-publish2.basic.upload_version'
+settings.tk-multi-publish2.nuke.post_phase:             '{config}/tk-multi-publish2/nuke/post_phase.py'
 
 settings.tk-multi-publish2.nukestudio.collector:        '@settings.tk-multi-publish2.basic.collector:{self}/nuke/collector.py:{config}/tk-multi-publish2/nukestudio/collector.py'
 settings.tk-multi-publish2.nukestudio.publish_files:    '@settings.tk-multi-publish2.basic.publish_files:{self}/nuke/publish_files.py'
@@ -118,6 +119,7 @@ settings.tk-multi-publish2.nuke:
   collector_settings: '@settings.tk-multi-publish2.nuke.collector.settings'
   path_info: '@settings.tk-multi-publish2.path_info'
   publish_plugins: '@settings.tk-multi-publish2.nuke.publish_plugins'
+  post_phase: '@settings.tk-multi-publish2.nuke.post_phase'
   location: '@apps.tk-multi-publish2.location'
 
 # NukeStudio

--- a/hooks/tk-multi-publish2/nuke/post_phase.py
+++ b/hooks/tk-multi-publish2/nuke/post_phase.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+import nuke
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class PostPhaseHook(HookBaseClass):
+    """
+    This hook defines methods that are executed after each phase of a publish:
+    validation, publish, and finalization. Each method receives the publish
+    tree instance being used by the publisher, giving full control to further
+    curate the publish tree including the publish items and the tasks attached
+    to them. See the :class:`PublishTree` documentation for additional details
+    on how to traverse the tree and manipulate it.
+    """
+
+    # See the developer docs for more information about the methods that can be
+    # defined here: https://developer.shotgunsoftware.com/tk-multi-publish2/
+    def post_validate(self, publish_tree):
+        """
+        This method is executed after the validation pass has completed for each
+        item in the tree, before the publish pass.
+
+        A :ref:`publish-api-tree` instance representing the items to publish,
+        and their associated tasks, is supplied as an argument. The tree can be
+        traversed in this method to inspect the items and tasks and process them
+        collectively. The instance can also be used to save the state of the
+        tree to disk for execution later or on another machine.
+
+        To glean information about the validation of particular items, you can
+        iterate over the items in the tree and introspect their
+        :py:attr:`~.api.PublishItem.properties` dictionary. This requires
+        customizing your publish plugins to populate any specific validation
+        information (failure/success) as well. You might, for example, set a
+        ``validation_failed`` boolean in the item properties, indicating if any
+        of the item's tasks failed. You could then include validation error
+        messages in a ``validation_errors`` list on the item, appending error
+        messages during task execution. Then, this method might look something
+        like this:
+
+        .. code-block:: python
+
+            def post_validate(self, publish_tree):
+
+                all_errors = []
+
+                # the publish tree is iterable, so you can easily loop over
+                # all items in the tree
+                for item in publish_tree:
+
+                    # access properties set on the item during the execution of
+                    # the attached publish plugins
+                    if item.properties.validation_failed:
+                        all_errors.extend(item.properties.validation_errors)
+
+                # process all validation issues here...
+
+        .. warning:: You will not be able to use the item's
+            :py:attr:`~.api.PublishItem.local_properties` in this hook since
+            :py:attr:`~.api.PublishItem.local_properties` are only accessible
+            during the execution of a publish plugin.
+
+        :param publish_tree: The :ref:`publish-api-tree` instance representing
+            the items to be published.
+        """
+        self.logger.debug("Executing post validate hook method...")
+
+        for item in publish_tree:
+            if item.name == "Current Nuke Session":
+                if 'write_node_paths_dict' in item.properties:
+                    item.properties['write_node_paths_dict'] = dict()
+                if 'visited_dict' in item.properties:
+                    item.properties['visited_dict'] = {node: 0 for node in nuke.allNodes(recurseGroups=True)}

--- a/hooks/tk-multi-publish2/nuke/publish.py
+++ b/hooks/tk-multi-publish2/nuke/publish.py
@@ -556,24 +556,27 @@ class NukePublishDDValidationPlugin(HookBaseClass):
     def _write_node_path_duplicacy(self, item):
         node_path = item.properties['node']['cached_path'].value()
         node_name = item.properties['node'].name()
-        all_paths = item.parent.properties['write_node_paths_dict'].values()
+        all_paths = item.parent.properties['write_node_paths_dict'].keys()
         if node_path in all_paths:
-            duplicate_path_node = [key for (key, value) in item.parent.properties['write_node_paths_dict'].items()
-                                   if value == node_path]
+            duplicate_path_nodes = item.parent.properties['write_node_paths_dict'].get(node_path, [])
 
-            if node_name not in duplicate_path_node:
+            if node_name in duplicate_path_nodes:
+                duplicate_path_nodes.remove(node_name)
+            if duplicate_path_nodes:
                 self.logger.error("Duplicate output path.",
                                   extra={
                                       "action_show_more_info": {
                                           "label": "Show Info",
                                           "tooltip": "Show node(s) with identical output path",
                                           "text": "Following node(s) have same output path as {}:\n\n{}".
-                                          format(node_name, '\n'.join(duplicate_path_node))
+                                          format(node_name, '\n'.join(duplicate_path_nodes))
                                       }
                                   }
                                   )
+                item.parent.properties['write_node_paths_dict'][node_path].add(node_name)
                 return False
-        item.parent.properties['write_node_paths_dict'] = {node_name: node_path}
+
+        item.parent.properties['write_node_paths_dict'].update({node_path: set([node_name])})
         return True
 
     @staticmethod

--- a/hooks/tk-multi-publish2/nuke/publish.py
+++ b/hooks/tk-multi-publish2/nuke/publish.py
@@ -558,7 +558,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
         node_name = item.properties['node'].name()
         all_paths = item.parent.properties['write_node_paths_dict'].keys()
         if node_path in all_paths:
-            duplicate_path_nodes = item.parent.properties['write_node_paths_dict'].get(node_path, [])
+            duplicate_path_nodes = item.parent.properties['write_node_paths_dict'].get(node_path, set())
 
             if node_name in duplicate_path_nodes:
                 duplicate_path_nodes.remove(node_name)
@@ -576,7 +576,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
                 item.parent.properties['write_node_paths_dict'][node_path].add(node_name)
                 return False
 
-        item.parent.properties['write_node_paths_dict'].update({node_path: set([node_name])})
+        item.parent.properties['write_node_paths_dict'][node_path] = {node_name}
         return True
 
     @staticmethod

--- a/hooks/tk-multi-publish2/nuke/publish.py
+++ b/hooks/tk-multi-publish2/nuke/publish.py
@@ -24,6 +24,7 @@ from Qt import QtWidgets, QtGui, QtCore
 HookBaseClass = sgtk.get_hook_baseclass()
 
 USER_FILE_SETTING_NAME = "Error On User File"
+NODE_CLASSES_TO_EXCLUDE = "Node Classes To Exclude"
 
 
 class DisplayUnpublishedFiles(QtWidgets.QWidget):
@@ -141,7 +142,15 @@ class NukePublishDDValidationPlugin(HookBaseClass):
                 "type": "bool",
                 "default_value": True,
                 "description": "Setting to Error the validation that checks for user paths in the nuke script."
-            }
+            },
+            NODE_CLASSES_TO_EXCLUDE: {
+                "type": "list",
+                "values": {
+                    "type": "str"
+                },
+                "default_value": ['LD_3DE_Classic_LD_Model'],
+                "description": "Node classes to be excluded which checking for file knob for user file validation"
+            },
         }
 
         schema.update(validation_schema)
@@ -209,7 +218,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
                 return False if log_method == "error" else True
         return True
 
-    def _collect_file_nodes_in_graph(self, node, visited_files):
+    def _collect_file_nodes_in_graph(self, node, visited_files, task_settings):
         """
         Traverses the graph for the write node being validated and collects all the
         nodes with file knobs and their respective file values
@@ -218,6 +227,9 @@ class NukePublishDDValidationPlugin(HookBaseClass):
         :param visited_files: Dictionary of nodes and associated files
         :return: Dictionary of all the file nodes in the graph and associated files
         """
+        if node.Class() in task_settings[NODE_CLASSES_TO_EXCLUDE].value:
+            self.visited_dict[node] = 1
+
         if self.visited_dict[node] == 0:
             # get the file path if exists
             if self._contains_active_file_knob(node):
@@ -229,7 +241,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
             dep = node.dependencies()
             if dep:
                 for item in dep:
-                    self._collect_file_nodes_in_graph(item, visited_files)
+                    self._collect_file_nodes_in_graph(item, visited_files, task_settings)
 
         return visited_files
 
@@ -397,7 +409,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
             'invalid': [],
         }
         visited_files = {}
-        self._collect_file_nodes_in_graph(item.properties['node'], visited_files)
+        self._collect_file_nodes_in_graph(item.properties['node'], visited_files, task_settings)
         self._check_file_validity(visited_files, suspicious_paths, valid_paths, show_path)
         item.parent.properties['visited_dict'] = self.visited_dict
 
@@ -548,16 +560,17 @@ class NukePublishDDValidationPlugin(HookBaseClass):
         if node_path in all_paths:
             duplicate_path_node = [key for (key, value) in item.parent.properties['write_node_paths_dict'].items()
                                    if value == node_path]
-            self.logger.error("Duplicate output path.",
-                              extra={
-                                  "action_show_more_info": {
-                                      "label": "Show Info",
-                                      "tooltip": "Show node(s) with identical output path",
-                                      "text": "Following node(s) have same output path as {}:\n\n{}".
-                                      format(node_name, '\n'.join(duplicate_path_node))
+            if not (len(duplicate_path_node) == 1 and duplicate_path_node[0] == node_name):
+                self.logger.error("Duplicate output path.",
+                                  extra={
+                                      "action_show_more_info": {
+                                          "label": "Show Info",
+                                          "tooltip": "Show node(s) with identical output path",
+                                          "text": "Following node(s) have same output path as {}:\n\n{}".
+                                          format(node_name, '\n'.join(duplicate_path_node))
+                                      }
                                   }
-                              }
-                              )
+                                  )
             return False
         item.parent.properties['write_node_paths_dict'] = {node_name: node_path}
         return True

--- a/hooks/tk-multi-publish2/nuke/publish.py
+++ b/hooks/tk-multi-publish2/nuke/publish.py
@@ -560,7 +560,8 @@ class NukePublishDDValidationPlugin(HookBaseClass):
         if node_path in all_paths:
             duplicate_path_node = [key for (key, value) in item.parent.properties['write_node_paths_dict'].items()
                                    if value == node_path]
-            if not (len(duplicate_path_node) == 1 and duplicate_path_node[0] == node_name):
+
+            if node_name not in duplicate_path_node:
                 self.logger.error("Duplicate output path.",
                                   extra={
                                       "action_show_more_info": {
@@ -571,7 +572,7 @@ class NukePublishDDValidationPlugin(HookBaseClass):
                                       }
                                   }
                                   )
-            return False
+                return False
         item.parent.properties['write_node_paths_dict'] = {node_name: node_path}
         return True
 


### PR DESCRIPTION
Added new setting Node Classes To Exclude to exclude nodes belonging to particular node class from user file path validation
Also, for duplicate path on write node validation, making sure we don’t treat the same node as duplicate path.